### PR TITLE
support the context of 'this' in processors

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ module.exports = function processorPlugin(bookshelf) {
       if (!Array.isArray(processes)) processes = [processes]
 
       processes.forEach(process => {
-        value = process(value)
+        value = process.call(this, value)
       })
 
       return value


### PR DESCRIPTION
## Question
When I try to get the attributes of the model in a processor, the value of 'this' is undefined. 

## Solution
Pass `this` to the processor. I use `process.call(this, value)` instead of `process(value)` in the plugin.